### PR TITLE
Title: Implement feature to enable/disable storage of research results

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -13,12 +13,25 @@ jobs:
       matrix:
         python-version: [3.11]
 
+    
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      
+      - name: Set storage mode to SQLite
+        run: echo -e "[storage]\nmode=0" > config/settings.cfg
+      
+      - name: Build .env file
+        run: |
+          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
+          echo "DB_HOST=localhost" >> .env
+          echo "DB_PORT=0" >> .env
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/bash_scripts/healthcheck.sh
+++ b/bash_scripts/healthcheck.sh
@@ -26,17 +26,17 @@ if ! attempt_request 3 1 http://0.0.0.0:8001/api/docs; then
   exit 1
 fi
 
-# Check 2: POST /api/research with product_url for beleza_na_web |  with 3 attempts and 1-second interval
-if ! attempt_request 3 1 -X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "product_url": "https://www.belezanaweb.com.br/amend-complete-repair-shampoo-250ml/ofertas-marketplace", "research_strategy": 0 }'; then
+# Check 2: POST /api/research with url for beleza_na_web |  with 3 attempts and 1-second interval
+if ! attempt_request 3 6 -X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "url": "https://www.belezanaweb.com.br/amend-complete-repair-shampoo-250ml/ofertas-marketplace", "strategy_option": 0 , "store_result": false}'; then
   exit 1
 fi
 
 # Check 3: POST /api/research with marketplace and marketplace_id for amazon |  with 3 attempts and 10-second interval
-if ! attempt_request 3 10 -X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "marketplace": "amazon", "marketplace_id": "B07GYX8QRJ" }'; then
+if ! attempt_request 3 24 -X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "marketplace": "amazon", "marketplace_id": "B07GYX8QRJ", "strategy_option": 0 , "store_result": false}'; then
   exit 1
 fi
 
 # Check 4: POST /api/research with marketplace and marketplace_id for mercado livre |  with 3 attempts and 10-second interval
-if ! attempt_request 3 10 -X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "product_url": "https://produto.mercadolivre.com.br/MLB-1448733946" }'; then
+if ! attempt_request 3 12 -X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "url": "https://produto.mercadolivre.com.br/MLB-1448733946", "strategy_option": 0 , "store_result": false}'; then
   exit 1
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,14 +46,14 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-      DB_HOST: ${DB_HOST}
-      DB_PORT: ${DB_PORT}
+      DB_HOST: postgres
+      DB_PORT: 5432
     healthcheck:
       test: ["CMD", "bash", "bash_scripts/healthcheck.sh"]
-      interval: 30s
-      timeout: 30s
-      retries: 5
-      start_period: 80s
+      interval: 2m  # Run every 2 minutes
+      timeout: 1m30s  # 90 seconds timeout
+      retries: 5  # Retry up to 5 times
+      start_period: 2m  # 2 minutes start period before counting failures
       
 volumes:
   data:

--- a/kami_pricing_analytics/data_collector/collector.py
+++ b/kami_pricing_analytics/data_collector/collector.py
@@ -10,17 +10,21 @@ from kami_pricing_analytics.data_collector.strategies.web_scraping.beleza_na_web
 from kami_pricing_analytics.data_collector.strategies.web_scraping.mercado_libre import (
     MercadoLibreScraper,
 )
+from kami_pricing_analytics.schemas.options import StrategyOptions
 
 
 class StrategyFactory:
     @staticmethod
-    def get_strategy(strategy: str, product_url: str) -> BaseScraper:
-        if strategy == 'web_scraping':
+    def get_strategy(strategy_option: int, product_url: str) -> BaseScraper:
+        if strategy_option == StrategyOptions.WEB_SCRAPING.value:
             if 'belezanaweb' in product_url:
                 return BelezaNaWebScraper(product_url=product_url)
             if 'amazon' in product_url:
                 return AmazonScraper(product_url=product_url)
             if 'mercadolivre' in product_url:
                 return MercadoLibreScraper(product_url=product_url)
+            raise ValueError('Unsupported marketplace for web scraping')
 
-        raise ValueError('Unsupported strategy')
+        raise ValueError(
+            'Unsupported strategy option. Available options are: 0 (WEB_SCRAPING)'
+        )

--- a/kami_pricing_analytics/data_collector/strategies/web_scraping/base_scraper.py
+++ b/kami_pricing_analytics/data_collector/strategies/web_scraping/base_scraper.py
@@ -179,8 +179,8 @@ class BaseScraper(BaseStrategy, ABC):
 
         return []
 
-    async def execute(self) -> dict:
-        return {'result': await self.scrap_product()}
+    async def execute(self) -> list:
+        return await self.scrap_product()
 
     async def close_http_client(self):
         await self.http_client.aclose()

--- a/kami_pricing_analytics/data_storage/base_storage.py
+++ b/kami_pricing_analytics/data_storage/base_storage.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from pydantic import BaseModel
 
 
-class DataStoreBase(BaseModel, ABC):
+class BaseStorage(BaseModel, ABC):
     """
     Abstract base class defining the contract for storage operations.
     All concrete storage mode implementations should inherit from this class

--- a/kami_pricing_analytics/data_storage/modes/database/relational/settings.py
+++ b/kami_pricing_analytics/data_storage/modes/database/relational/settings.py
@@ -1,4 +1,4 @@
-from pydantic import Field, SecretStr
+from pydantic import ConfigDict, Field, SecretStr
 from pydantic_settings import BaseSettings
 
 
@@ -9,6 +9,13 @@ class DatabaseSettings(BaseSettings):
     db_host: str = Field(default='localhost')
     db_port: int
     db_driver: str
+
+    model_config = ConfigDict(
+        title='Database Settings',
+        str_strip_whitespace=True,
+        env_file='.env',
+        env_file_encoding='utf-8',
+    )
 
     @property
     def db_url(self) -> str:

--- a/kami_pricing_analytics/data_storage/modes/database/relational/storage.py
+++ b/kami_pricing_analytics/data_storage/modes/database/relational/storage.py
@@ -5,16 +5,16 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeMeta, sessionmaker
 
+from kami_pricing_analytics.data_storage.base_storage import BaseStorage
 from kami_pricing_analytics.data_storage.modes.database.relational.models import (
     PricingResearchModel,
 )
 from kami_pricing_analytics.data_storage.modes.database.relational.settings import (
     DatabaseSettings,
 )
-from kami_pricing_analytics.data_storage.storage_base import DataStoreBase
 
 
-class DatabaseStorage(DataStoreBase):
+class DatabaseStorage(BaseStorage):
     def __init__(self, settings: DatabaseSettings):
         super().__init__(**settings.model_dump(exclude={'driver'}))
 

--- a/kami_pricing_analytics/interface/api/fastapi/app.py
+++ b/kami_pricing_analytics/interface/api/fastapi/app.py
@@ -1,46 +1,21 @@
 import configparser
-import logging
 import os
 from typing import Any, Dict, List
 
-from fastapi import APIRouter, BackgroundTasks, FastAPI, HTTPException, status
-from pydantic import BaseModel, model_validator
+from fastapi import APIRouter, FastAPI, HTTPException, status
+from fastapi.responses import JSONResponse
 
-from kami_pricing_analytics.data_storage.storage_factory import (
-    StorageModeOptions,
+from kami_pricing_analytics.interface.api.pricing_research_request import (
+    PricingResearchRequest,
 )
-from kami_pricing_analytics.schemas.options import StrategyOptions
 from kami_pricing_analytics.schemas.pricing_research import PricingResearch
 
 research_app = FastAPI(
     title='KAMI-Pricing Analytics API',
     description="API to conduct pricing research over a product's URL.",
-    version='0.5.0',
+    version='0.6.0',
 )
 api_router = APIRouter()
-
-settings_path = os.path.join('config', 'settings.cfg')
-settings = configparser.ConfigParser()
-settings.read(settings_path)
-storage_mode = StorageModeOptions(settings.getint('storage', 'MODE'))
-
-
-class ResearchRequest(BaseModel):
-    product_url: str = None
-    marketplace: str = None
-    marketplace_id: str = None
-    research_strategy: int = StrategyOptions.WEB_SCRAPING.value
-    store_research: bool = False
-
-    @model_validator(mode='after')
-    def check_input_required_fields(self):
-        if not self.product_url and (
-            not self.marketplace or not self.marketplace_id
-        ):
-            raise ValueError(
-                'Either Product URL or marketplace and marketplace_id is required to conduct research.'
-            )
-        return self
 
 
 @research_app.post(
@@ -48,35 +23,29 @@ class ResearchRequest(BaseModel):
     response_model=Dict[str, List[Dict[str, Any]]],
     status_code=status.HTTP_200_OK,
 )
-async def research(
-    product_data: ResearchRequest, background_tasks: BackgroundTasks
-):
+async def research(request: PricingResearchRequest):
     try:
-        if product_data.product_url:
-            pricing_research = PricingResearch(url=product_data.product_url)
-        else:
-            pricing_research = PricingResearch(
-                marketplace=product_data.marketplace,
-                marketplace_id=product_data.marketplace_id,
-            )
-        pricing_research.set_strategy(product_data.research_strategy)
-        pricing_research.set_storage(mode_option=storage_mode)
 
-        await pricing_research.conduct_research()
+        sellers = await request.post()
+        return {'result': sellers}
 
-        background_tasks.add_task(pricing_research.store_research)
-
-        return pricing_research.result
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
         )
     except Exception as e:
-        logging.error(f'Unexpected error: {str(e)}', exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='An error occurred while scraping the product.',
+            detail=f'An unexpected error occurred: {str(e)}',
         )
+
+
+@research_app.exception_handler(ValueError)
+async def handle_value_error(request, exc):
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content={'message': str(exc)},
+    )
 
 
 research_app.include_router(api_router, prefix='/api')

--- a/kami_pricing_analytics/interface/api/pricing_research_request.py
+++ b/kami_pricing_analytics/interface/api/pricing_research_request.py
@@ -1,0 +1,78 @@
+import asyncio
+import configparser
+import os
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from kami_pricing_analytics.data_storage.storage_factory import (
+    StorageModeOptions,
+)
+from kami_pricing_analytics.schemas.options import StrategyOptions
+from kami_pricing_analytics.schemas.pricing_research import PricingResearch
+from kami_pricing_analytics.services.pricing_service import PricingService
+
+root_folder = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+settings_path = os.path.join('config', 'settings.cfg')
+settings = configparser.ConfigParser()
+settings.read(settings_path)
+storage_mode = StorageModeOptions(settings.getint('storage', 'MODE'))
+
+
+class PricingResearchRequest(BaseModel):
+    url: Optional[str] = Field(default=None)
+    marketplace: Optional[str] = Field(default=None)
+    marketplace_id: Optional[str] = Field(default=None)
+    strategy_option: int = Field(default=StrategyOptions.WEB_SCRAPING.value)
+    store_result: bool = Field(default=False)
+    service: PricingService = Field(default=None)
+
+    def validate_strategy_option(self):
+        if self.strategy_option not in StrategyOptions._value2member_map_:
+            raise ValueError(
+                f'Invalid strategy option {self.strategy_option}. Available options are: {list(StrategyOptions)}'
+            )
+        return self
+
+    def validate_research(self):
+        if self.url:
+            return self
+
+        if not self.marketplace or not self.marketplace_id:
+            raise ValueError(
+                'Either Product URL or marketplace and marketplace_id is required to conduct research.'
+            )
+
+        return self
+
+    @model_validator(mode='after')
+    def validate_input(self):
+        self.validate_strategy_option()
+        self.validate_research()
+        return self
+
+    @model_validator(mode='after')
+    def get_service_instance(self):
+        research = PricingResearch(
+            url=self.url,
+            marketplace=self.marketplace,
+            marketplace_id=self.marketplace_id,
+        )
+        self.service = PricingService(
+            strategy_option=self.strategy_option,
+            research=research,
+            store_result=self.store_result,
+            storage_mode=storage_mode,
+        )
+        return self
+
+    async def post(self):
+        self.validate_input()
+        self.service.set_strategy()
+        await self.service.conduct_research()
+
+        if self.store_result:
+            self.service.set_storage()
+            asyncio.create_task(self.service.store_research())
+
+        return self.service.research.sellers

--- a/kami_pricing_analytics/schemas/options.py
+++ b/kami_pricing_analytics/schemas/options.py
@@ -1,4 +1,3 @@
-import re
 from enum import Enum
 
 

--- a/kami_pricing_analytics/services/pricing_service.py
+++ b/kami_pricing_analytics/services/pricing_service.py
@@ -1,0 +1,69 @@
+import configparser
+import json
+import os
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from kami_pricing_analytics.data_collector.collector import StrategyFactory
+from kami_pricing_analytics.data_collector.strategies.base_strategy import (
+    BaseStrategy,
+)
+from kami_pricing_analytics.data_storage.base_storage import BaseStorage
+from kami_pricing_analytics.data_storage.storage_factory import (
+    StorageFactory,
+    StorageModeOptions,
+)
+from kami_pricing_analytics.schemas.options import StrategyOptions
+from kami_pricing_analytics.schemas.pricing_research import PricingResearch
+
+
+class PricingService(BaseModel):
+
+    strategy_option: int = Field(default=StrategyOptions.WEB_SCRAPING.value)
+    strategy: BaseStrategy = Field(default=None)
+
+    store_result: bool = Field(default=False)
+    storage_mode: int = Field(default=0)
+    storage: BaseStorage = Field(default=None)
+
+    research: PricingResearch = Field(default=None)
+
+    model_config = ConfigDict(
+        title='Pricing Service',
+        from_attributes=True,
+        use_enum_values=True,
+        str_strip_whitespace=True,
+    )
+
+    @model_validator(mode='after')
+    def set_strategy(self):
+        self.strategy = StrategyFactory.get_strategy(
+            strategy_option=self.strategy_option,
+            product_url=str(self.research.url),
+        )
+        return self
+
+    @model_validator(mode='after')
+    def set_storage(self):
+
+        if self.store_result:
+            self.storage = StorageFactory.get_mode(mode=self.storage_mode)
+        return self
+
+    async def conduct_research(self):
+        """Execute the assigned strategy to conduct research and store the results if necessary."""
+
+        result = await self.strategy.execute()
+
+        self.research.update_research_data(result)
+
+    async def store_research(self):
+        if self.store_result:
+            research_data = self.research.model_dump_json(
+                exclude={'model_config'}
+            )
+            research_data = json.loads(research_data)
+            research_data['strategy'] = StrategyOptions(
+                self.strategy_option
+            ).name
+            await self.storage.save(research_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kami_pricing_analytics"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Scalable FastAPI-based Pricing Analytics API for Research Data Management and Analysis"
 authors = ["Maicon de Menezes <maicondmenezes@gmail.com>"]
 readme = "README.md"

--- a/tests/interface/api/test_princig_research_request.py
+++ b/tests/interface/api/test_princig_research_request.py
@@ -1,0 +1,108 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from kami_pricing_analytics.interface.api.pricing_research_request import (
+    PricingResearchRequest,
+)
+from kami_pricing_analytics.schemas.options import StrategyOptions
+from kami_pricing_analytics.schemas.pricing_research import PricingResearch
+from kami_pricing_analytics.services.pricing_service import PricingService
+
+
+class TestPricingResearchRequest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.valid_data = {
+            'url': 'https://www.amazon.com.br/dp/B07GYX8QRJ',
+            'marketplace': 'AMAZON',
+            'marketplace_id': 'B07GYX8QRJ',
+            'strategy_option': StrategyOptions.WEB_SCRAPING.value,
+            'store_result': True,
+        }
+        self.request = PricingResearchRequest(**self.valid_data)
+
+    def test_create_instance_with_valid_data(self):
+        self.assertEqual(self.request.url, self.valid_data['url'])
+        self.assertEqual(
+            self.request.marketplace, self.valid_data['marketplace']
+        )
+        self.assertEqual(
+            self.request.marketplace_id, self.valid_data['marketplace_id']
+        )
+        self.assertEqual(
+            self.request.strategy_option, self.valid_data['strategy_option']
+        )
+        self.assertEqual(
+            self.request.store_result, self.valid_data['store_result']
+        )
+        self.assertIsInstance(self.request.service, PricingService)
+        self.assertIsInstance(self.request.service.research, PricingResearch)
+
+    def test_wrong_strategy_option_raises_error(self):
+        self.request.strategy_option = 99
+        with self.assertRaises(ValueError):
+            self.request.validate_strategy_option()
+
+    def test_missing_url_and_marketplace_info_raises_error(self):
+        self.request.url = None
+        self.request.marketplace = None
+        with self.assertRaises(ValueError):
+            self.request.validate_research()
+
+    @patch(
+        'kami_pricing_analytics.services.pricing_service.PricingService.conduct_research',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'kami_pricing_analytics.services.pricing_service.PricingService.store_research',
+        new_callable=AsyncMock,
+    )
+    async def test_when_not_store_result_post_should_not_call_store_research(
+        self, mock_store_research, mock_conduct_research
+    ):
+        self.request.store_result = False
+        await self.request.post()
+        mock_store_research.assert_not_called()
+        mock_conduct_research.assert_awaited()
+
+    @patch('asyncio.create_task')
+    @patch(
+        'kami_pricing_analytics.services.pricing_service.PricingService.store_research',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'kami_pricing_analytics.services.pricing_service.PricingService.conduct_research',
+        new_callable=AsyncMock,
+    )
+    async def test_when_store_result_post_should_create_store_research_task(
+        self, mock_conduct_research, mock_store_research, mock_create_task
+    ):
+        mock_store_research.return_value = await asyncio.sleep(0)
+        self.request.store_result = True
+
+        await self.request.post()
+
+        mock_create_task.assert_called_once()
+        mock_conduct_research.assert_awaited()
+
+    @patch(
+        'kami_pricing_analytics.services.pricing_service.PricingService.conduct_research',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'kami_pricing_analytics.services.pricing_service.PricingService.store_research',
+        new_callable=AsyncMock,
+    )
+    async def test_when_post_is_called_should_return_sellers(
+        self, mock_store_research, mock_conduct_research
+    ):
+        mock_conduct_research.return_value = await asyncio.sleep(0)
+        mock_store_research.return_value = await asyncio.sleep(0)
+
+        result = await self.request.post()
+
+        self.assertEqual(result, self.request.service.research.sellers)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/schemas/test_pricing_research.py
+++ b/tests/schemas/test_pricing_research.py
@@ -1,130 +1,71 @@
 import unittest
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
 
 from pydantic import ValidationError
 
-from kami_pricing_analytics.data_collector.strategies.web_scraping.amazon import (
-    AmazonScraper,
-)
+from kami_pricing_analytics.schemas.options import StrategyOptions
 from kami_pricing_analytics.schemas.pricing_research import PricingResearch
 
 
-class TestPricingResearch(unittest.IsolatedAsyncioTestCase):
+class TestPricingResearch(unittest.TestCase):
     def setUp(self):
         self.valid_data = {
-            'id': 1,
             'sku': 'SKU12345',
-            'marketplace': 'amazon',
-            'marketplace_id': 'MLB-3340422055',
+            'url': 'https://www.amazon.com.br/dp/B07GYX8QRJ',
+            'marketplace': 'AMAZON',
+            'marketplace_id': 'B07GYX8QRJ',
             'description': 'A test product',
-            'url': 'https://www.amazon.com.br/dp/MLB-3340422055',
-            'conducted_at': datetime.now(tz=timezone.utc),
-            'result': {'key': 'value'},
+            'brand': 'Test Brand',
+            'category': 'Electronics',
         }
-        self.invalid_data_types = {
-            'id': 'not an integer',
-            'marketplace': 'not a valid marketplace',
+        self.invalid_data = {
             'sku': 12345,
-            'description': True,
             'url': 'not a valid URL',
-            'conducted_at': 'not a datetime',
-            'result': 'not a dict',
         }
 
-    def test_create_instance_with_only_url(self):
-        instance = PricingResearch(url=self.valid_data['url'])
+    def test_create_instance_with_valid_data(self):
+        instance = PricingResearch(**self.valid_data)
         self.assertEqual(str(instance.url), self.valid_data['url'])
-
-    def test_create_instance_with_marketplace_info(self):
-        instance = PricingResearch(
-            url=self.valid_data['url'],
-            marketplace=self.valid_data['marketplace'],
-            marketplace_id=self.valid_data['marketplace_id'],
-        )
         self.assertEqual(instance.marketplace, self.valid_data['marketplace'])
-        self.assertEqual(
-            instance.marketplace_id, self.valid_data['marketplace_id']
-        )
 
-    def test_failure_with_missing_required_fields(self):
-        with self.assertRaises(ValueError):
-            PricingResearch(maekretplace=self.valid_data['marketplace'])
+    def test_create_instance_with_invalid_data(self):
+        with self.assertRaises(ValidationError):
+            PricingResearch(**self.invalid_data)
 
-    def test_set_url_with_correct_marketplace_info(self):
+    def test_url_set_from_marketplace_info(self):
         instance = PricingResearch(
-            marketplace=self.valid_data['marketplace'],
-            marketplace_id=self.valid_data['marketplace_id'],
+            marketplace='AMAZON', marketplace_id='B07GYX8QRJ'
         )
         instance.set_url()
-        self.assertEqual(
-            instance.url,
-            'https://www.amazon.com.br/dp/MLB-3340422055',
+        self.assertEqual(instance.url, self.valid_data['url'])
+
+    def test_marketplace_info_extracted_from_url(self):
+        instance = PricingResearch(
+            url='https://www.amazon.com.br/dp/B07GYX8QRJ'
         )
-
-    def test_set_url_with_incorrect_marketplace_info(self):
-        with self.assertRaises(ValueError):
-            instance = PricingResearch(
-                marketplace='not a valid marketplace',
-                marketplace_id='MLB-3340422055',
-            )
-
-    def test_failure_with_invalid_data_for_each_field(self):
-        for field, value in self.invalid_data_types.items():
-            with self.assertRaises(ValidationError):
-                PricingResearch(**{field: value})
-
-    def test_extract_marketplace_from_url(self):
-        instance = PricingResearch(url=self.valid_data['url'])
+        instance.extract_marketplace_from_url()
         self.assertEqual(instance.marketplace, 'amazon')
 
-    def test_extract_marketplace_id_from_url(self):
-        instance = PricingResearch(url=self.valid_data['url'])
-        self.assertEqual(instance.marketplace_id, 'MLB-3340422055')
+    def test_marketplace_id_extracted_from_url(self):
+        instance = PricingResearch(
+            url='https://www.amazon.com.br/dp/B07GYX8QRJ'
+        )
+        instance.extract_marketplace_id_from_url()
+        self.assertEqual(instance.marketplace_id, 'B07GYX8QRJ')
 
-    def test_get_marketplace_info_from_url(self):
-        instance = PricingResearch(url=self.valid_data['url'])
-        self.assertEqual(instance.marketplace, 'amazon')
-        self.assertEqual(instance.marketplace_id, 'MLB-3340422055')
-
-    def test_success_define_web_scraping_strategy(self):
-        instance = PricingResearch(url=self.valid_data['url'])
-        instance.set_strategy(0)
-        self.assertIsInstance(instance.strategy, AmazonScraper)
-
-    def test_failure_define_web_scraping_strategy(self):
-        instance = PricingResearch(url=self.valid_data['url'])
-        with self.assertRaises(ValueError):
-            instance.set_strategy(99)
-
-    @patch(
-        'kami_pricing_analytics.data_collector.strategies.web_scraping.amazon.AmazonScraper.execute',
-        new_callable=AsyncMock,
-    )
-    async def test_success_conduct_research(self, mock_execute):
-
-        mock_execute.return_value = {'key': 'value'}
-
+    def test_update_research_data(self):
         instance = PricingResearch(**self.valid_data)
-        instance.set_strategy(0)
-        await instance.conduct_research()
-
-        self.assertEqual(instance.result, {'key': 'value'})
-
-    @patch(
-        'kami_pricing_analytics.data_storage.storage_factory.StorageFactory.get_mode'
-    )
-    async def test_store_research_success(self, mock_get_mode):
-        mock_storage = AsyncMock()
-        mock_storage.save = AsyncMock(return_value=None)
-
-        mock_get_mode.return_value = mock_storage
-
-        instance = PricingResearch(**self.valid_data)
-        instance.set_storage(0)
-        await instance.store_research()
-
-        mock_storage.save.assert_awaited_once()
+        result_data = [
+            {
+                'marketplace_id': 'B07GYX8QRJ',
+                'description': 'Updated product',
+                'brand': 'Updated Brand',
+                'category': 'Updated Category',
+            }
+        ]
+        instance.update_research_data(result_data)
+        self.assertEqual(instance.description, 'Updated product')
+        self.assertEqual(instance.brand, 'Updated Brand')
+        self.assertEqual(instance.category, 'Updated Category')
 
 
 if __name__ == '__main__':

--- a/tests/selenium_crawler.ipynb
+++ b/tests/selenium_crawler.ipynb
@@ -2,17 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from kami_pricing_analytics.data_collector.strategies.web_scraping.mercado_libre import MercadoLibreScraper\n",
     "product_url=\"https://produto.mercadolivre.com.br/MLB-1448733946\"\n",
@@ -22,98 +14,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mercado Livre\n",
-      "https://lista.mercadolivre.com.br/_CustId_185899562?item_id=MLB1448733946&category_id=MLB32130&seller_id=185899562&client=recoview-selleritems&recos_listing=true\n",
-      "185899562\n",
-      "ZUKA COSMETICOS\n",
-      "R$145,90 \n",
-      "Uso Obrigatorio \n",
-      "Truss Uso Obrigatório Reconstrutor Capilar 260ml \n",
-      "https://click1.mercadolivre.com.br/mclics/clicks/external/MLB/count?a=AG%2FkhoMN7qqZjIuXigXcqwaKp4zxXgsafhU%2Bc4LmAuM77NZ5%2FuywqlpvcrE3jU7N25vRdU%2B1l9FgJYhcVEwOpj%2FV%2Fh7GK%2BOyGEza14nuUdx02Vh0JOYJi0GAvpLHbeyJrHgT%2B7ld%2FCxCcltRFo0fU9E0z6919d6M3FbFFBwvvtU2BnKaHrTnWjVLXiRwBLvj2YEv7ZOD9I0NL7UxOO9HtNCFGTsvD9voDldPKhrjkac7UhuI2zk5VKpAS4bwQh6OTOv0hQ9ogdUtOk7%2BsX7ZkDTc69JlcRvla1L858rS5vp0GQF%2B3uKZCFGcf0MHpX8x8pczK4nVJReFId2ktO%2FH8UWwfrH9bgzHIh%2Fv3LVpLJ3saTiuD1RQ3GTNOUkLUUsywFh5DMQHGdbznAU42QJIyregPsTVrnCIBPm0ah5hf4dCBXkwO8LzbV2HEbMBogDFNriCczuXsGrwuLtKiOr0Kv1kjsl4JedxHJlBAdH6pssVIszTqlV8yix4m4YlU3jA6jdgSL2QuxBDJMiRn5ukHMoGhqSnCy8w%2BgWzdYW059B1waC6W%2BciGbWP%2F20BICylBuMGKVYAhScq0rrbnda9yBKXHqucUFB9dO1yzeOBakxI2iq9ciezY11zroUYohJ%2F%2Bv0B64oTehIl0AGbmO4SMlJaXy2Yw6mKeZblEnVP9YFCDiugHJiZZYpf03QlfnKMz0qx1ItE&e=mclics%2Fadvertising-results-augmenter-on%2B15098%2Cmclics%2Fvariant-candidates%2B31710%2Cmclics%2Fpseudo-search-pads-buybox%2B7708%2Cmclics%2Fmax-bid-item-factor%2B23928%2Cmclics%2Fsearch-list-ad-algorithm%2BDEFAULT%2Cmclics%2Fmax-bid-capped%2B36382%2Cmclics%2Fpads-score-mla%2B17263%2Cmclics%2Flax-top-domain%2B23443&rb=x\n",
-      "\n",
-      "\n",
-      "https://www.mercadolivre.com.br/pagina/magazine_24h6145?item_id=MLB1506360965&category_id=MLB32130&seller_id=281324034&client=recoview-selleritems&recos_listing=true#origin=vip&component=sellerData&typeSeller=eshop\n",
-      "281324034\n",
-      "MAGAZINE 24H\n",
-      "R$127,49 \n",
-      "Truss \n",
-      "Truss Uso Obrigatório Reconstrutor Capilar - 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-1506360965-truss-uso-obrigatorio-reconstrutor-capilar-260ml-_JM#position=24&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://www.mercadolivre.com.br/pagina/beauty.secret?item_id=MLB2667574241&category_id=MLB32130&seller_id=357167813&client=recoview-selleritems&recos_listing=true#origin=vip&component=sellerData&typeSeller=eshop\n",
-      "357167813\n",
-      "BEAUTY SECRET\n",
-      "R$135,99 \n",
-      "Truss \n",
-      "Truss Uso Obrigatório 260ml Reconstrutor Capilar \n",
-      "https://produto.mercadolivre.com.br/MLB-2667574241-truss-uso-obrigatorio-260ml-reconstrutor-capilar-_JM#position=29&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://lista.mercadolivre.com.br/_CustId_193253947?item_id=MLB2201113270&category_id=MLB32130&seller_id=193253947&client=recoview-selleritems&recos_listing=true\n",
-      "193253947\n",
-      "M2BEAUTY__\n",
-      "R$129,80 \n",
-      "Truss \n",
-      "Truss Uso Obrigatório - Reconstrutor Capilar 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-2201113270-truss-uso-obrigatorio-reconstrutor-capilar-260ml-_JM#position=32&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://lista.mercadolivre.com.br/_CustId_256850616?item_id=MLB2102441874&category_id=MLB32130&seller_id=256850616&client=recoview-selleritems&recos_listing=true\n",
-      "256850616\n",
-      "A.G.SANTOS COSMÉTICOS\n",
-      "R$127,41 \n",
-      "Hair Vip \n",
-      "Uso Obrigatório Truss Reconstrutor Capilar 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-2102441874-uso-obrigatorio-truss-reconstrutor-capilar-260ml-_JM#position=37&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://loja.mercadolivre.com.br/teruya-perfumaria?item_id=MLB1822089374&category_id=MLB32130&official_store_id=1235&client=recoview-selleritems&recos_listing=true\n",
-      "None\n",
-      "Teruya Perfumaria\n",
-      "R$147,90 \n",
-      "Truss \n",
-      "Reconstrutor Capilar Uso Obrigatório Truss 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-1822089374-reconstrutor-capilar-uso-obrigatorio-truss-260ml-_JM#position=38&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://www.mercadolivre.com.br/pagina/mixdamaria?item_id=MLB3633699945&category_id=MLB32130&seller_id=638240438&client=recoview-selleritems&recos_listing=true\n",
-      "638240438\n",
-      "MIXDAMARIA\n",
-      "R$119 \n",
-      "Truss \n",
-      "Truss Uso Obrigatório - Reconstrutor Capilar 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-3633699945-truss-uso-obrigatorio-reconstrutor-capilar-260ml-_JM#position=43&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://lista.mercadolivre.com.br/_CustId_468042452?item_id=MLB1468646785&category_id=MLB32130&seller_id=468042452&client=recoview-selleritems&recos_listing=true\n",
-      "468042452\n",
-      "YOUBELEZA\n",
-      "R$149,99 \n",
-      "Truss \n",
-      "Uso Obrigatório Truss - Reconstrutor Capilar 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-1468646785-uso-obrigatorio-truss-reconstrutor-capilar-260ml-_JM#position=51&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n",
-      "https://www.mercadolivre.com.br/pagina/mixdamaria?item_id=MLB4540623140&category_id=MLB32130&seller_id=638240438&client=recoview-selleritems&recos_listing=true#origin=vip&component=sellerData&typeSeller=eshop\n",
-      "638240438\n",
-      "MIXDAMARIA\n",
-      "R$119 \n",
-      "Truss \n",
-      "Truss Uso Obrigatório - Reconstrutor Capilar 260ml \n",
-      "https://produto.mercadolivre.com.br/MLB-4540623140-truss-uso-obrigatorio-reconstrutor-capilar-260ml-_JM#position=54&search_layout=grid&type=item&tracking_id=d00f863a-79b0-4f09-b25e-fed04198c3eb\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Mercado Livre\")\n",
     "for seller in mlb_result['result']:\n",
@@ -163,7 +66,70 @@
    "source": [
     "print(\"Beleza na Web\")\n",
     "for seller in beleza_result['result']:\n",
-    "  print(f\"{seller['seller_url']}\\n{seller['seller_id']}\\n{seller['seller_name']}\\n{seller['price']} \\n{seller['brand']} \\n{seller['description']} \\n{seller['product_url']}\\n\\n\")"
+    "  print(f\"{seller['seller_url']}\\n{seller['seller_id']}\\n{seller['seller_name']}\\n{seller['price']} \\n{seller['brand']} \\n{seller['description']}-X 'POST' 'http://0.0.0.0:8001/api/research' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ \"url\": \"https://produto.mercadolivre.com.br/MLB-1448733946\", \"strategy_option\": 0 , \"store\": false }' \\n{seller['product_url']}\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kami_pricing_analytics.interface.api.fastapi.app import ResearchRequest\n",
+    "marketplace=\"amazon\"\n",
+    "marketplace_id=\"B07GYX8QRJ\"\n",
+    "url=\"https://www.belezanaweb.com.br/amend-complete-repair-shampoo-250ml/ofertas-marketplace\"\n",
+    "research = ResearchRequest(url=url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(research)\n",
+    "research.validate_input()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kami_pricing_analytics.schemas.pricing_research import PricingResearch\n",
+    "research_data = research.model_dump(exclude_none=True, exclude={\"store\"})\n",
+    "pricing_research = PricingResearch(**research_data)\n",
+    "pricing_research.set_strategy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await pricing_research.strategy.execute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WEB_SCRAPING\n"
+     ]
+    }
+   ],
+   "source": [
+    "from kami_pricing_analytics.schemas.options import StrategyOptions\n",
+    "\n",
+    "print(f'{StrategyOptions(0).name}')"
    ]
   }
  ],

--- a/tests/services/test_pricing_service.py
+++ b/tests/services/test_pricing_service.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from kami_pricing_analytics.data_collector.strategies.web_scraping.base_scraper import (
+    BaseScraper,
+)
+from kami_pricing_analytics.data_storage.modes.database.relational.sqlite import (
+    SQLiteStorage,
+)
+from kami_pricing_analytics.schemas.pricing_research import PricingResearch
+from kami_pricing_analytics.services.pricing_service import PricingService
+
+
+class TestPricingService(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.research = PricingResearch(url='https://amazon.com/product')
+        self.pricing_service = PricingService(
+            research=self.research, store_result=True
+        )
+
+    def test_default_strategy_should_be_web_scraping(self):
+        self.assertIsInstance(self.pricing_service.strategy, BaseScraper)
+
+    def test_default_storage_should_be_SQLite(self):
+        self.assertIsInstance(self.pricing_service.storage, SQLiteStorage)
+
+    @patch(
+        'kami_pricing_analytics.data_collector.strategies.web_scraping.amazon.AmazonScraper.execute',
+        new_callable=AsyncMock,
+    )
+    async def test_when_conduct_research_updates_research_correctly(
+        self, mock_execute
+    ):
+        mock_execute.return_value = [
+            {
+                'marketplace_id': '12345',
+                'brand': 'Test Brand',
+                'description': 'Test Description',
+                'category': 'Electronics',
+            }
+        ]
+
+        self.pricing_service.store_result = False
+        await self.pricing_service.conduct_research()
+        mock_execute.assert_awaited_once()
+
+        self.assertEqual(self.research.marketplace_id, '12345')
+        self.assertEqual(self.research.brand, 'Test Brand')
+        self.assertEqual(self.research.description, 'Test Description')
+        self.assertEqual(self.research.category, 'Electronics')
+
+    @patch(
+        'kami_pricing_analytics.data_storage.modes.database.relational.sqlite.SQLiteStorage.save',
+        new_callable=AsyncMock,
+    )
+    async def test_when_store_result_is_true_call_storage_save(
+        self, mock_save
+    ):
+        await self.pricing_service.store_research()
+
+        self.pricing_service.storage.save.assert_awaited_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/todo.md
+++ b/todo.md
@@ -26,3 +26,9 @@
 ### [] utilizar Celery com Redis para lidar com as requisições em estratégia de fila
 
 ### [] adicionar tratamento de paginação (principalmente no mercado livre)
+
+### [] adicionar método get à API
+
+### [] implementar funções de recuperação da informação através do storage
+
+### [] implementar um algoritmo inteligente para o get retornar dados do banco de dados de acordo com a última pesquisa, ou realizar uma pesquisa caso a validade da última pesquisa tenha expirado, ou não for encontrado nenhum registro para aquele produto no banco


### PR DESCRIPTION
Summary:
This commit introduces version 0.6.0, featuring a new capability that allows users to choose whether or not to store the results of pricing research via the API. The updates include modifications to the health check scripts, Docker configurations, data collector and storage modules, and the FastAPI application logic to support this functionality.

Key Changes:
1. Updated the API endpoints to accept a new parameter 'store_result' which determines if the results are stored.
2. Modified the healthcheck.sh script to accommodate changes in API request structure and increased intervals for health checks.
3. Revised Docker-compose environment variables and healthcheck configurations to enhance service stability.
4. Enhanced the StrategyFactory in data_collector to use a new parameter naming convention and introduced error handling for unsupported marketplaces.
5. Refactored the data storage classes to inherit from a new base class 'BaseStorage', improving the abstraction of storage operations.
6. Adjusted the storage factory to facilitate easy addition and retrieval of different storage modes through a centralized configuration.
7. Overhauled the FastAPI application structure to utilize Pydantic models for request validation and streamlined error handling.
8. Extended unit tests to cover the new functionality and ensure compliance with the updated business logic.

Version: 0.6.0
Branch: enable_disable_storage